### PR TITLE
Prevent unbounded chat logs

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,8 @@ docker run --rm -p 5000:5000 -e OPENAI_API_KEY=your-key-here interactive-agent
 ```
 
 You can optionally set `FLASK_SECRET` to specify the Flask session secret key.
+The server will keep up to `MAX_LOG_LENGTH` messages in memory for each session
+(default 100). Older messages are written to files under `logs/`.
 
 ## Note
 


### PR DESCRIPTION
## Summary
- avoid unbounded growth of `chat_logs` by keeping only a limited number of entries in memory
- persist pruned entries to `logs/` files
- document new behaviour and `MAX_LOG_LENGTH` option in README

## Testing
- `python -m py_compile interactive_agent.py`