### PR TITLE
Add unit test for orchestrate and CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,22 @@
+name: CI
+
+on:
+  pull_request:
+  push:
+    branches: [ main ]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v4
+        with:
+          python-version: '3.10'
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt
+      - name: Run tests
+        run: |
+          pytest

--- a/README.md
+++ b/README.md
@@ -29,6 +29,8 @@ docker run --rm -p 5000:5000 -e OPENAI_API_KEY=your-key-here interactive-agent
 ```
 
 You can optionally set `FLASK_SECRET` to specify the Flask session secret key.
+The server will keep up to `MAX_LOG_LENGTH` messages in memory for each session
+(default 100). Older messages are written to files under `logs/`.
 
 ## Note
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,3 @@
+flask
+openai
+pytest

--- a/tests/test_interactive_agent.py
+++ b/tests/test_interactive_agent.py
@@ -1,0 +1,57 @@
+import os
+import sys
+import types
+import importlib
+import pytest
+
+# Provide a stub openai module before importing interactive_agent
+openai_stub = types.SimpleNamespace()
+class ChatCompletion:
+    @staticmethod
+    async def acreate(*args, **kwargs):
+        return types.SimpleNamespace(
+            choices=[types.SimpleNamespace(message=types.SimpleNamespace(content=""))]
+        )
+openai_stub.ChatCompletion = ChatCompletion
+openai_stub.api_key = None
+sys.modules['openai'] = openai_stub
+
+# Ensure API key env var so interactive_agent does not raise
+os.environ.setdefault("OPENAI_API_KEY", "test")
+
+interactive_agent = importlib.import_module("interactive_agent")
+
+
+@pytest.mark.asyncio
+async def test_orchestrate_runs_all_agents(monkeypatch):
+    async def fake_ask_agent(role, messages):
+        if role == "solution_evaluation":
+            return "APPROVED"
+        return f"{role} response"
+
+    monkeypatch.setattr(interactive_agent, "_ask_agent", fake_ask_agent)
+
+    state, evaluation = await interactive_agent._orchestrate("build")
+
+    expected_roles = [
+        "market_research",
+        "demand_analysis",
+        "requirement_def",
+        "system_design",
+        "server_design",
+        "infrastructure",
+        "db_tuning",
+        "code_generation",
+        "code_review",
+        "test_generation",
+        "security_audit",
+        "deployment",
+        "project_manager",
+        "solution_evaluation",
+    ]
+
+    assert evaluation == "APPROVED"
+    assert set(state.keys()) == set(expected_roles)
+    for role in expected_roles[:-1]:
+        assert state[role] == f"{role} response"
+    assert state["solution_evaluation"] == "APPROVED"


### PR DESCRIPTION
## Summary
- add a unit test for `_orchestrate` in `interactive_agent.py`
- require Flask, OpenAI and pytest via `requirements.txt`
- run tests on GitHub Actions
- merge latest changes from `master` (log pruning and README note)

## Testing
- `pip install pytest` *(fails: Could not connect to proxy)*
- `apt-get update` *(fails: Could not resolve 'archive.ubuntu.com')*
- `pytest -q` *(fails: command not found)*