### PR TITLE
Configure ADK MCP from environment

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,9 @@ The application uses several variables that can be set via Docker or your shell:
 - `ADK_MCP_URL` – base URL to the Model Context Protocol service.
 - `ADK_MCP_TOKEN` – authentication token for MCP requests.
 
+When set, these variables are passed to every `LlmAgent` so the ADK can
+communicate with an MCP service for tool execution and state sharing.
+
 ## Usage
 
 ### Local execution


### PR DESCRIPTION
## Summary
- read `ADK_MCP_URL` and `ADK_MCP_TOKEN` and pass them into `LlmAgent`
- verify MCP parameters are forwarded in tests
- document MCP variables in the README

## Testing
- `python -m unittest discover -s tests -v`