### PR TITLE
Integrate ADK output_key

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,8 @@ stage in `WORKFLOW_ORDER` of `interactive_agent.py` becomes an `LlmAgent` with a
 specific system prompt.  These agents run sequentially via `SequentialAgent` and
 are wrapped in a `LoopAgent` so the evaluator can trigger automatic improvement
 loops.  ADK handles passing state between agents and executing the full
-pipeline, allowing new roles to be inserted easily.
+pipeline, allowing new roles to be inserted easily.  Each agent now specifies an
+`output_key` so its response is written to the shared state automatically.
 
 ## Requirements
 

--- a/interactive_agent.py
+++ b/interactive_agent.py
@@ -129,18 +129,31 @@ IMPROVEMENT_FLOW = ["code_generation", "code_review", "test_generation"]
 
 def _build_workflow(max_iterations: int = 1):
     sub_agents = [
-        LlmAgent(name=role, prompt=SYSTEM_PROMPTS[role], model=MODEL, **_MCP_KWARGS)
+        LlmAgent(
+            name=role,
+            prompt=SYSTEM_PROMPTS[role],
+            model=MODEL,
+            output_key=role,
+            **_MCP_KWARGS,
+        )
         for role in WORKFLOW_ORDER
     ]
     seq = SequentialAgent(sub_agents=sub_agents)
     improvement_agents = [
-        LlmAgent(name=role, prompt=SYSTEM_PROMPTS[role], model=MODEL, **_MCP_KWARGS)
+        LlmAgent(
+            name=role,
+            prompt=SYSTEM_PROMPTS[role],
+            model=MODEL,
+            output_key=role,
+            **_MCP_KWARGS,
+        )
         for role in IMPROVEMENT_FLOW
     ]
     evaluator = LlmAgent(
         name="solution_evaluation",
         prompt=SYSTEM_PROMPTS["solution_evaluation"],
         model=MODEL,
+        output_key="solution_evaluation",
         **_MCP_KWARGS,
     )
     return LoopAgent(


### PR DESCRIPTION
## Summary
- store each agent's response using `output_key`
- note ADK `output_key` feature in README

## Testing
- `python -m unittest tests/test_interactive_agent.py -v`