### PR TITLE
Enhance toolset integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,8 +30,10 @@ The application uses several variables that can be set via Docker or your shell:
 - `ADK_MCP_URL` – base URL to the Model Context Protocol service.
 - `ADK_MCP_TOKEN` – authentication token for MCP requests.
 
-When set, these variables are passed to every `LlmAgent` so the ADK can
-communicate with an MCP service for tool execution and state sharing.
+When both `ADK_MCP_URL` and `ADK_MCP_TOKEN` are provided each `LlmAgent`
+receives an `MCPToolset` connection so agents can run tools through the MCP
+service.  The `code_generation` role will use the `python` tool when needed to
+execute snippets.
 
 ## Usage
 

--- a/interactive_agent.py
+++ b/interactive_agent.py
@@ -2,7 +2,7 @@ import os
 import asyncio
 import openai
 from flask import Flask, request, render_template_string, session
-from adk import LlmAgent, SequentialAgent, LoopAgent
+from adk import LlmAgent, SequentialAgent, LoopAgent, MCPToolset
 from uuid import uuid4
 
 API_KEY = os.getenv("OPENAI_API_KEY")
@@ -21,6 +21,11 @@ if MCP_URL:
     _MCP_KWARGS["mcp_url"] = MCP_URL
 if MCP_TOKEN:
     _MCP_KWARGS["mcp_token"] = MCP_TOKEN
+
+_TOOLSET = None
+if MCP_URL and MCP_TOKEN:
+    _TOOLSET = MCPToolset(mcp_url=MCP_URL, mcp_token=MCP_TOKEN)
+    _MCP_KWARGS["toolset"] = _TOOLSET
 
 
 SYSTEM_PROMPTS = {
@@ -51,7 +56,8 @@ SYSTEM_PROMPTS = {
         "Refine the database schema and suggest indexing or optimisation."
     ),
     "code_generation": (
-        "Generate or update application source code based on the design."
+        "Generate or update application source code based on the design. "
+        "Use available tools like 'python' for quick execution when helpful."
     ),
     "code_review": (
         "Review the current code and suggest fixes or improvements."

--- a/tests/test_interactive_agent.py
+++ b/tests/test_interactive_agent.py
@@ -40,10 +40,17 @@ flask_stub = types.SimpleNamespace(
     render_template_string=lambda *a, **kw: "",
     session={},
 )
+created_toolset = {}
+class MCPToolset:
+    def __init__(self, mcp_url=None, mcp_token=None, **kwargs):
+        created_toolset['url'] = mcp_url
+        created_toolset['token'] = mcp_token
+
 adk_stub = types.SimpleNamespace(
     LlmAgent=object,
     SequentialAgent=object,
     LoopAgent=object,
+    MCPToolset=MCPToolset,
 )
 sys.modules.setdefault("flask", flask_stub)
 sys.modules.setdefault("adk", adk_stub)
@@ -105,6 +112,9 @@ class OrchestrateUsesAdkTest(unittest.IsolatedAsyncioTestCase):
         for kwargs in used_kwargs:
             self.assertEqual(kwargs.get("mcp_url"), os.environ["ADK_MCP_URL"])
             self.assertEqual(kwargs.get("mcp_token"), os.environ["ADK_MCP_TOKEN"])
+            self.assertIs(kwargs.get("toolset"), interactive_agent._TOOLSET)
+        self.assertEqual(created_toolset.get('url'), os.environ["ADK_MCP_URL"])
+        self.assertEqual(created_toolset.get('token'), os.environ["ADK_MCP_TOKEN"])
         self.assertEqual(evaluation, "APPROVED")
         for role in interactive_agent.WORKFLOW_ORDER:
             self.assertEqual(state[role], f"{role} response")


### PR DESCRIPTION
## Summary
- create MCPToolset on startup when MCP URL/token are provided
- pass toolset to every agent in the workflow
- instruct code generation agent to use the `python` tool
- document new toolset behaviour
- update tests for the new toolset handling

## Testing
- `python tests/test_interactive_agent.py -v`
